### PR TITLE
Fixing the hovering on the heading of About Section

### DIFF
--- a/components/functions/OneTab.jsx
+++ b/components/functions/OneTab.jsx
@@ -2,7 +2,7 @@ export function OneTab({ text, isActive, setActive }) {
   return (
     <span
       onClick={() => setActive()}
-      className={`mb-5   cursor-pointer text-2xl ${
+      className={`mb-5 cursor-pointer text-2xl ${
         isActive ? 'border-b-2 border-primary-purple text-primary-purple' : 'text-dark-grey'
       }`}
     >

--- a/components/functions/OneTab.jsx
+++ b/components/functions/OneTab.jsx
@@ -1,17 +1,12 @@
-export function OneTab({
-    text,
-    isActive,
-    setActive,
-  }) {
-    return (
-      <span 
-        onClick={() => setActive()}
-        className={`cursor-pointer   hover:text-primary-purple text-2xl mb-5 ${
-          isActive ? 'text-primary-purple border-b-2 border-primary-purple' : 'text-dark-grey'
-        }`}
-      >
-        {text}
-      </span>
-    );
-  }
-  
+export function OneTab({ text, isActive, setActive }) {
+  return (
+    <span
+      onClick={() => setActive()}
+      className={`mb-5   cursor-pointer text-2xl ${
+        isActive ? 'border-b-2 border-primary-purple text-primary-purple' : 'text-dark-grey'
+      }`}
+    >
+      {text}
+    </span>
+  );
+}


### PR DESCRIPTION
###  PR DESCRIPTION

- This PR Fix bugs in the About section

### TASKS COMPLETED

- [x] Remove Purple Color while hovering over the heading
- [ ] Underlayment has to flow smoothly to where you clicked from its previous position

### HOW CAN THIS PR BE TESTED

```
git clone https://github.com/TheGymRwanda/unit8-maroon
git checkout fix/about-section-hovering
npm install
npm run dev

```

### BEFORE SUBMITTING YOUR PR, ENSURE IT HAS THE FOLLOWING

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

### TICKET NUMBER

#033: https://www.notion.so/apeunit/Desktop-Description-Section-Headings-onclick-and-hovering-effects-8ce4881dbc9d428b8637a346841808fd